### PR TITLE
Add test cases for depth option in dependency traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Property | Type | Default | Description
 `requireConfig` | String | null | RequireJS config for resolving aliased modules
 `webpackConfig` | String | null | Webpack config for resolving aliased modules
 `tsConfig` | String\|Object | null | TypeScript config for resolving aliased modules - Either a path to a tsconfig file or an object containing the config
+`depth` | Number | null | Maximum dependency depth from source files to display
 `layout` | String | dot | Layout to use in the graph
 `rankdir` | String | LR | Sets the [direction](https://graphviz.gitlab.io/_pages/doc/info/attrs.html#d:rankdir) of the graph layout
 `fontName` | String | Arial | Font name to use in the graph

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -32,6 +32,7 @@ program
 	.option('--require-config <file>', 'path to RequireJS config')
 	.option('--webpack-config <file>', 'path to webpack config')
 	.option('--ts-config <file>', 'path to typescript config')
+	.option('--depth <integer>', 'maximum depth from source files to draw')
 	.option('--include-npm', 'include shallow NPM modules', false)
 	.option('--no-color', 'disable color in output and image', false)
 	.option('--no-spinner', 'disable progress spinner', false)
@@ -110,6 +111,19 @@ if (program.webpackConfig) {
 
 if (program.tsConfig) {
 	config.tsConfig = program.tsConfig;
+}
+
+if ('depth' in program) {
+	config.depth = program.depth;
+}
+
+if ('depth' in config) {
+	config.depth = Number(config.depth);
+
+	if (!Number.isInteger(config.depth) || config.depth < 0) {
+		console.log('%s %s', chalk.red('✖'), 'Invalid depth');
+		process.exit(1);
+	}
 }
 
 if (program.includeNpm) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -14,6 +14,7 @@ const defaultConfig = {
 	requireConfig: null,
 	webpackConfig: null,
 	tsConfig: null,
+	depth: null,
 	rankdir: 'LR',
 	layout: 'dot',
 	fontName: 'Arial',

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -107,24 +107,19 @@ class Tree {
 	 * @return {Object}
 	 */
 	generateTree(files) {
-		const depTree = {};
-		const visited = {};
+		const modules = {};
 		const nonExistent = [];
 		const npmPaths = {};
 		const pathCache = {};
 
 		files.forEach((file) => {
-			if (visited[file]) {
-				return;
-			}
-
-			Object.assign(depTree, dependencyTree({
+			dependencyTree({
 				filename: file,
 				directory: this.baseDir,
 				requireConfig: this.config.requireConfig,
 				webpackConfig: this.config.webpackConfig,
 				tsConfig: this.config.tsConfig,
-				visited: visited,
+				visited: modules,
 				filter: (dependencyFilePath, traversedFilePath) => {
 					let dependencyFilterRes = true;
 					const isNpmPath = this.isNpmPath(dependencyFilePath);
@@ -145,10 +140,10 @@ class Tree {
 				},
 				detective: this.config.detectiveOptions,
 				nonExistent: nonExistent
-			}));
+			});
 		});
 
-		let tree = this.convertTree(depTree, {}, pathCache, npmPaths);
+		let tree = this.convertTree(modules, files, this.config.depth);
 
 		for (const npmKey in npmPaths) {
 			const id = this.processPath(npmKey, pathCache);
@@ -171,27 +166,57 @@ class Tree {
 	/**
 	 * Convert deep tree produced by dependency-tree to a
 	 * shallow (one level deep) tree used by madge.
-	 * @param  {Object} depTree
+	 * @param  {Object} modules
 	 * @param  {Object} tree
-	 * @param  {Object} pathCache
+	 * @param  {number?} depthLimit
 	 * @return {Object}
 	 */
-	convertTree(depTree, tree, pathCache) {
-		for (const key in depTree) {
-			const id = this.processPath(key, pathCache);
+	convertTree(modules, tree, depthLimit) {
+		const self = this;
+		const depths = {};
+		const deepDependencies = {};
 
-			if (!tree[id]) {
-				tree[id] = [];
-
-				for (const dep in depTree[key]) {
-					tree[id].push(this.processPath(dep, pathCache));
+		function calculateDepths(tree, depth) {
+			if (depth <= depthLimit) {
+				for (let i = 0; i < tree.length; i++) {
+					const dependency = tree[i];
+					depths[dependency] = true;
+					calculateDepths(Object.keys(modules[dependency]), depth + 1);
 				}
-
-				this.convertTree(depTree[key], tree, pathCache);
 			}
 		}
 
-		return tree;
+		function getDeepDependencies(dependency) {
+			if (deepDependencies[dependency] === null) {
+				return [];
+			}
+
+			if (!(dependency in deepDependencies)) {
+				deepDependencies[dependency] = null;
+				deepDependencies[dependency] = [...new Set(Object.keys(modules[dependency]).flatMap(
+					(dependency) => dependency in depths ? [dependency] : getDeepDependencies(dependency)
+				))];
+			}
+
+			return deepDependencies[dependency];
+		}
+
+		const pathCache = {};
+		const result = {};
+
+		if (!Number.isInteger(depthLimit)) {
+			Object.entries(modules).forEach(([module, dependencies]) => {
+				result[self.processPath(module, pathCache)] = Object.keys(dependencies).map((dependency) => self.processPath(dependency, pathCache));
+			});
+		} else {
+			calculateDepths(tree, 0);
+
+			Object.keys(depths).forEach((module) => {
+				result[self.processPath(module, pathCache)] = getDeepDependencies(module).map((dependency) => self.processPath(dependency, pathCache));
+			});
+		}
+
+		return result;
 	}
 
 	/**

--- a/test/api.js
+++ b/test/api.js
@@ -336,4 +336,56 @@ describe('API', () => {
 				.catch(done);
 		});
 	});
+
+	// Test cases for depth option
+	describe('depth option', () => {
+		const baseDir = path.join(__dirname, 'cjs');
+		const entryFile = path.join(baseDir, 'a.js');
+
+		it('limits the depth of dependency traversal correctly', (done) => {
+			madge(entryFile, { depth: 1 }).then((res) => {
+				res.obj().should.eql({
+					'a.js': ['b.js', 'c.js']
+				});
+				done();
+			}).catch(done);
+		});
+
+		it('includes correct dependencies at different depth levels', (done) => {
+			madge(entryFile, { depth: 2 }).then((res) => {
+				res.obj().should.eql({
+					'a.js': ['b.js', 'c.js'],
+					'b.js': ['c.js']
+				});
+				done();
+			}).catch(done);
+		});
+
+		it('does not include dependencies beyond the specified depth', (done) => {
+			madge(entryFile, { depth: 0 }).then((res) => {
+				res.obj().should.eql({
+					'a.js': []
+				});
+				done();
+			}).catch(done);
+		});
+
+		it('ensures full traversal when depth is not specified', (done) => {
+			madge(entryFile).then((res) => {
+				res.obj().should.eql({
+					'a.js': ['b.js', 'c.js'],
+					'b.js': ['c.js'],
+					'c.js': []
+				});
+				done();
+			}).catch(done);
+		});
+
+		it('handles invalid depth values appropriately', (done) => {
+			madge(entryFile, { depth: -1 }).catch((err) => {
+				err.message.should.match(/Invalid depth/);
+				done();
+			}).catch(done);
+		});
+	});
 });


### PR DESCRIPTION
Adds support for a new `depth` configuration option in the dependency analysis tool, allowing users to limit the depth of dependency traversal. This update includes changes to the README, CLI, and core library files to accommodate the new option.

- **README.md**: Documents the new `depth` option, explaining its purpose and usage.
- **CLI (`bin/cli.js`)**: Introduces the `--depth` command-line argument, enabling users to specify the maximum dependency depth directly from the CLI.
- **Configuration Handling (`lib/api.js`)**: Adds `depth` to the default configuration object, ensuring it's recognized as a valid option within the application.
- **Dependency Traversal (`lib/tree.js`)**: Implements the logic to respect the `depth` option during dependency tree generation, modifying both `generateTree` and `convertTree` functions to filter dependencies based on the specified depth.
- **Error Handling**: Enhances error checking for the `depth` option, ensuring that invalid values result in a clear error message and termination of the process.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pahen/madge/pull/318?shareId=8c20dc25-ab00-4b7c-94b0-e939ab45dc1f).